### PR TITLE
Update repo for modern PyTorch

### DIFF
--- a/demo/live.py
+++ b/demo/live.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import torch
-from torch.autograd import Variable
 import cv2
 import time
 from imutils.video import FPS, WebcamVideoStream
@@ -21,9 +20,10 @@ def cv2_demo(net, transform):
     def predict(frame):
         height, width = frame.shape[:2]
         x = torch.from_numpy(transform(frame)[0]).permute(2, 0, 1)
-        x = Variable(x.unsqueeze(0))
-        y = net(x)  # forward pass
-        detections = y.data
+        x = x.unsqueeze(0)
+        with torch.no_grad():
+            y = net(x)  # forward pass
+        detections = y
         # scale each detection back up to the image
         scale = torch.Tensor([width, height, width, height])
         for i in range(detections.size(1)):

--- a/eval.py
+++ b/eval.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import torch
 import torch.nn as nn
 import torch.backends.cudnn as cudnn
-from torch.autograd import Variable
 from data import VOC_ROOT, VOCAnnotationTransform, VOCDetection, BaseTransform
 from data import VOC_CLASSES as labelmap
 import torch.utils.data as data
@@ -378,11 +377,12 @@ def test_net(save_folder, net, cuda, dataset, transform, top_k,
     for i in range(num_images):
         im, gt, h, w = dataset.pull_item(i)
 
-        x = Variable(im.unsqueeze(0))
+        x = im.unsqueeze(0)
         if args.cuda:
             x = x.cuda()
         _t['im_detect'].tic()
-        detections = net(x).data
+        with torch.no_grad():
+            detections = net(x)
         detect_time = _t['im_detect'].toc(average=False)
 
         # skip j = 0, because it's the background class

--- a/layers/box_utils.py
+++ b/layers/box_utils.py
@@ -165,8 +165,8 @@ def log_sum_exp(x):
     Args:
         x (Variable(tensor)): conf_preds from conf layers
     """
-    x_max = x.data.max()
-    return torch.log(torch.sum(torch.exp(x-x_max), 1, keepdim=True)) + x_max
+    x_max = x.detach().max()
+    return torch.log(torch.sum(torch.exp(x - x_max), 1, keepdim=True)) + x_max
 
 
 # Original author: Francisco Massa:

--- a/layers/modules/l2norm.py
+++ b/layers/modules/l2norm.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 from torch.autograd import Function
-from torch.autograd import Variable
 import torch.nn.init as init
 
 class L2Norm(nn.Module):

--- a/ssd.py
+++ b/ssd.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.autograd import Variable
 from layers import *
 from data import voc, coco
 import os
@@ -31,7 +30,7 @@ class SSD(nn.Module):
         self.num_classes = num_classes
         self.cfg = (coco, voc)[num_classes == 21]
         self.priorbox = PriorBox(self.cfg)
-        self.priors = Variable(self.priorbox.forward(), volatile=True)
+        self.register_buffer('priors', self.priorbox.forward())
         self.size = size
 
         # SSD network
@@ -100,7 +99,7 @@ class SSD(nn.Module):
                 loc.view(loc.size(0), -1, 4),                   # loc preds
                 self.softmax(conf.view(conf.size(0), -1,
                              self.num_classes)),                # conf preds
-                self.priors.type(type(x.data))                  # default boxes
+                self.priors.to(x.device)                  # default boxes
             )
         else:
             output = (

--- a/test.py
+++ b/test.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 import torch.backends.cudnn as cudnn
 import torchvision.transforms as transforms
-from torch.autograd import Variable
 from data import VOC_ROOT, VOC_CLASSES as labelmap
 from PIL import Image
 from data import VOCAnnotationTransform, VOCDetection, BaseTransform, VOC_CLASSES
@@ -44,7 +43,7 @@ def test_net(save_folder, net, cuda, testset, transform, thresh):
         img = testset.pull_image(i)
         img_id, annotation = testset.pull_anno(i)
         x = torch.from_numpy(transform(img)[0]).permute(2, 0, 1)
-        x = Variable(x.unsqueeze(0))
+        x = x.unsqueeze(0)
 
         with open(filename, mode='a') as f:
             f.write('\nGROUND TRUTH FOR: '+img_id+'\n')
@@ -53,8 +52,9 @@ def test_net(save_folder, net, cuda, testset, transform, thresh):
         if cuda:
             x = x.cuda()
 
-        y = net(x)      # forward pass
-        detections = y.data
+        with torch.no_grad():
+            y = net(x)      # forward pass
+        detections = y
         # scale each detection back up to the image
         scale = torch.Tensor([img.shape[1], img.shape[0],
                              img.shape[1], img.shape[0]])

--- a/train.py
+++ b/train.py
@@ -6,7 +6,6 @@ import os
 import sys
 import time
 import torch
-from torch.autograd import Variable
 import torch.nn as nn
 import torch.optim as optim
 import torch.backends.cudnn as cudnn
@@ -165,11 +164,11 @@ def train():
         images, targets = next(batch_iterator)
 
         if args.cuda:
-            images = Variable(images.cuda())
-            targets = [Variable(ann.cuda(), volatile=True) for ann in targets]
+            images = images.cuda()
+            targets = [ann.cuda() for ann in targets]
         else:
-            images = Variable(images)
-            targets = [Variable(ann, volatile=True) for ann in targets]
+            images = images
+            targets = [ann for ann in targets]
         # forward
         t0 = time.time()
         out = net(images)
@@ -180,15 +179,15 @@ def train():
         loss.backward()
         optimizer.step()
         t1 = time.time()
-        loc_loss += loss_l.data[0]
-        conf_loss += loss_c.data[0]
+        loc_loss += loss_l.item()
+        conf_loss += loss_c.item()
 
         if iteration % 10 == 0:
             print('timer: %.4f sec.' % (t1 - t0))
-            print('iter ' + repr(iteration) + ' || Loss: %.4f ||' % (loss.data[0]), end=' ')
+            print('iter ' + repr(iteration) + ' || Loss: %.4f ||' % (loss.item()), end=' ')
 
         if args.visdom:
-            update_vis_plot(iteration, loss_l.data[0], loss_c.data[0],
+            update_vis_plot(iteration, loss_l.item(), loss_c.item(),
                             iter_plot, epoch_plot, 'append')
 
         if iteration != 0 and iteration % 5000 == 0:
@@ -211,12 +210,12 @@ def adjust_learning_rate(optimizer, gamma, step):
 
 
 def xavier(param):
-    init.xavier_uniform(param)
+    init.xavier_uniform_(param)
 
 
 def weights_init(m):
     if isinstance(m, nn.Conv2d):
-        xavier(m.weight.data)
+        xavier(m.weight)
         m.bias.data.zero_()
 
 


### PR DESCRIPTION
## Summary
- remove deprecated `Variable` usage
- switch to `torch.no_grad` and `.item()` calls
- register prior boxes as buffers
- update Xavier initialization style
- adjust loss functions to use new API

## Testing
- `python -m py_compile train.py ssd.py eval.py test.py demo/live.py layers/modules/multibox_loss.py layers/modules/l2norm.py layers/box_utils.py`
- ❌ `python train.py --help` (failed to run due to missing torch module)


------
https://chatgpt.com/codex/tasks/task_e_6847a02d94a8832daadeca0fa085f11a