### PR TITLE
Fix augmentations random.choice incompatibility

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import types
 from numpy import random
+import random as py_random
 
 
 def intersect(box_a, box_b):
@@ -235,7 +236,7 @@ class RandomSampleCrop(object):
         height, width, _ = image.shape
         while True:
             # randomly choose a mode
-            mode = random.choice(self.sample_options)
+            mode = py_random.choice(self.sample_options)
             if mode is None:
                 return image, boxes, labels
 


### PR DESCRIPTION
## Summary
- update augmentations to use Python's `random.choice` for sample selection

## Testing
- `python test.py --version` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python train.py -h` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6847a249cac8832d9cde945471c7b83b