### PR TITLE
Fix MultiBoxLoss shape mismatch

### DIFF
--- a/layers/modules/multibox_loss.py
+++ b/layers/modules/multibox_loss.py
@@ -86,10 +86,10 @@ class MultiBoxLoss(nn.Module):
         # Compute max conf across batch for hard negative mining
         batch_conf = conf_data.view(-1, self.num_classes)
         loss_c = log_sum_exp(batch_conf) - batch_conf.gather(1, conf_t.view(-1, 1))
+        loss_c = loss_c.view(num, -1)
 
         # Hard Negative Mining
         loss_c[pos] = 0  # filter out pos boxes for now
-        loss_c = loss_c.view(num, -1)
         _, loss_idx = loss_c.sort(1, descending=True)
         _, idx_rank = loss_idx.sort(1)
         num_pos = pos.long().sum(1, keepdim=True)


### PR DESCRIPTION
## Summary
- fix boolean mask indexing in MultiBoxLoss

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6847a31bbc70832db1af422b827654fe