### PR TITLE
Fix dataset label mapping for custom single-class dataset

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,5 +1,5 @@
 from .voc0712 import VOCDetection, VOCAnnotationTransform, VOC_CLASSES, VOC_ROOT
-from .voc_custom import VOCCustomDetection
+from .voc_custom import VOCCustomDetection, CUSTOM_CLASSES
 
 from .coco import COCODetection, COCOAnnotationTransform, COCO_CLASSES, COCO_ROOT, get_label_map
 from .config import *

--- a/data/config.py
+++ b/data/config.py
@@ -40,3 +40,19 @@ coco = {
     'clip': True,
     'name': 'COCO',
 }
+
+# Custom dataset configuration (single class: human)
+custom = {
+    'num_classes': 2,
+    'lr_steps': (80000, 100000, 120000),
+    'max_iter': 120000,
+    'feature_maps': [38, 19, 10, 5, 3, 1],
+    'min_dim': 300,
+    'steps': [8, 16, 32, 64, 100, 300],
+    'min_sizes': [30, 60, 111, 162, 213, 264],
+    'max_sizes': [60, 111, 162, 213, 264, 315],
+    'aspect_ratios': [[2], [2, 3], [2, 3], [2, 3], [2], [2]],
+    'variance': [0.1, 0.2],
+    'clip': True,
+    'name': 'CUSTOM',
+}

--- a/data/voc_custom.py
+++ b/data/voc_custom.py
@@ -10,12 +10,18 @@ if sys.version_info[0] == 2:
 else:
     import xml.etree.ElementTree as ET
 
-from .voc0712 import VOCAnnotationTransform, VOC_CLASSES
+from .voc0712 import VOCAnnotationTransform
+
+# only one class in this dataset
+CUSTOM_CLASSES = ('human',)
 
 class VOCCustomDetection(data.Dataset):
     """VOC Detection Dataset without year-specific subfolders."""
     def __init__(self, root, image_sets=['trainval'],
-                 transform=None, target_transform=VOCAnnotationTransform(),
+                 transform=None,
+                 target_transform=VOCAnnotationTransform(
+                     class_to_ind=dict(zip(CUSTOM_CLASSES,
+                                          range(len(CUSTOM_CLASSES))))),
                  dataset_name='VOCCUSTOM'):
         self.root = root
         self.image_set = image_sets

--- a/ssd.py
+++ b/ssd.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from layers import *
-from data import voc, coco
+from data import voc, coco, custom
 import os
 
 
@@ -28,7 +28,12 @@ class SSD(nn.Module):
         super(SSD, self).__init__()
         self.phase = phase
         self.num_classes = num_classes
-        self.cfg = (coco, voc)[num_classes == 21]
+        if num_classes == 21:
+            self.cfg = voc
+        elif num_classes == 201:
+            self.cfg = coco
+        else:
+            self.cfg = custom
         self.priorbox = PriorBox(self.cfg)
         self.register_buffer('priors', self.priorbox.forward())
         self.size = size

--- a/train.py
+++ b/train.py
@@ -87,10 +87,10 @@ def train():
                                transform=SSDAugmentation(cfg['min_dim'],
                                                          MEANS))
     elif args.dataset == 'CUSTOM':
-        cfg = voc
-        dataset = VOCCustomDetection(root=args.dataset_root,
-                                     transform=SSDAugmentation(cfg['min_dim'],
-                                                               MEANS))
+        cfg = custom
+        dataset = VOCCustomDetection(
+            root=args.dataset_root,
+            transform=SSDAugmentation(cfg['min_dim'], MEANS))
 
     if args.visdom:
         import visdom


### PR DESCRIPTION
## Summary
- support a custom dataset containing a single "human" class
- expose custom class names via `CUSTOM_CLASSES`
- use the new `custom` config when `--dataset CUSTOM` is selected
- pick correct config in SSD model depending on the number of classes

## Testing
- `python -m py_compile data/voc_custom.py ssd.py train.py data/config.py data/__init__.py`
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6847ab12dbac832d98a9c196bcd42bdd